### PR TITLE
Update e2e_ci_internal.fmf

### DIFF
--- a/generic/e2e_ci_internal.fmf
+++ b/generic/e2e_ci_internal.fmf
@@ -2,7 +2,7 @@ summary: test plan for sudo internal gating testing
 
 
 adjust:
-  - when: distro == centos-stream-10
+  - when: distro == centos-stream-10, centos-stream-9
     enabled: false
     because: we want to run this plan only for rhel distros
 


### PR DESCRIPTION
Plan should be run only for rhel distros.